### PR TITLE
Try to resolve compiler resolve time out

### DIFF
--- a/Source/Ease.swift
+++ b/Source/Ease.swift
@@ -177,7 +177,9 @@ extension Ease {
     
     /// Easing equation function for a sinusoidal (sin(t)) easing out: decelerating from zero velocity.
     public static let outSine = Ease(equation:{ (t, b, c, d) in
-        return c*sin(t/d * (Double.pi/2))+b
+        let halfPi = Double.pi/2
+        let sined = sin(t/d * (halfPi))
+        return c*sined+b
     })
     
     /// Easing equation function for a sinusoidal (sin(t)) easing in/out: acceleration until halfway, then deceleration.


### PR DESCRIPTION
I am receiving this issue on xcode 12:

`The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions`

Try to resolve this with

```
let halfPi = Double.pi/2
let sined = sin(t/d * halfPi)
return c * sined + b
```